### PR TITLE
📦 support versioning in git

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt export-subst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=61",
-    "setuptools_scm[toml]>=6.4"
+    "setuptools_scm[toml]>=7"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Following [https://scikit-hep.org/developer/packaging#versioning-mediumhigh-priority](https://scikit-hep.org/developer/packaging#versioning-mediumhigh-priority), this PR adds the necessary steps to allow git archives (including the ones generated from GitHub) to also support versioning.
This requires setuptools_scm>=7.