### PR TITLE
🩹 quickfix for changes in SabreLayout 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires-python = ">=3.9"
 dynamic = ["version"]
 
 dependencies = [
-    "mqt.bench>=0.3.0",
+    "mqt.bench>=0.3.4,<0.4.0",
     "sb3_contrib>=1.6.2",
     "scikit-learn>=1.0.2",
     "importlib_metadata>=4.4; python_version < '3.10'",

--- a/src/mqt/predictor/ml/Predictor.py
+++ b/src/mqt/predictor/ml/Predictor.py
@@ -8,7 +8,7 @@ from typing import Any
 import matplotlib.pyplot as plt
 import numpy as np
 from joblib import Parallel, delayed, load
-from mqt.bench.utils import qiskit_helper, tket_helper
+from mqt.bench import qiskit_helper, tket_helper
 from mqt.predictor import ml, reward, utils
 from pytket.extensions.qiskit import tk_to_qiskit
 from qiskit import QuantumCircuit

--- a/src/mqt/predictor/rl/helper.py
+++ b/src/mqt/predictor/rl/helper.py
@@ -56,7 +56,6 @@ else:
 reward_functions = Literal["fidelity", "critical_depth", "mix", "gate_ratio"]
 
 logger = logging.getLogger("mqtpredictor")
-SABRELAYOUT_BREAKING_CHANGE_VERSION = "0.40.0"
 
 
 def qcompile(qc: QuantumCircuit | str, opt_objective: reward_functions = "fidelity") -> QuantumCircuit:
@@ -161,9 +160,7 @@ def get_actions_layout() -> list[dict[str, Any]]:
         {
             "name": "SabreLayout",
             "transpile_pass": lambda c: [
-                SabreLayout(coupling_map=CouplingMap(c), skip_routing=True)
-                if metadata.version("qiskit") >= SABRELAYOUT_BREAKING_CHANGE_VERSION
-                else SabreLayout(coupling_map=CouplingMap(c)),
+                SabreLayout(coupling_map=CouplingMap(c), skip_routing=True),
                 FullAncillaAllocation(coupling_map=CouplingMap(c)),
                 EnlargeWithAncilla(),
                 ApplyLayout(),

--- a/src/mqt/predictor/rl/helper.py
+++ b/src/mqt/predictor/rl/helper.py
@@ -56,6 +56,7 @@ else:
 reward_functions = Literal["fidelity", "critical_depth", "mix", "gate_ratio"]
 
 logger = logging.getLogger("mqtpredictor")
+SABRELAYOUT_BREAKING_CHANGE_VERSION = "0.40.0"
 
 
 def qcompile(qc: QuantumCircuit | str, opt_objective: reward_functions = "fidelity") -> QuantumCircuit:
@@ -160,7 +161,9 @@ def get_actions_layout() -> list[dict[str, Any]]:
         {
             "name": "SabreLayout",
             "transpile_pass": lambda c: [
-                SabreLayout(coupling_map=CouplingMap(c)),
+                SabreLayout(coupling_map=CouplingMap(c), skip_routing=True)
+                if metadata.version("qiskit") >= SABRELAYOUT_BREAKING_CHANGE_VERSION
+                else SabreLayout(coupling_map=CouplingMap(c)),
                 FullAncillaAllocation(coupling_map=CouplingMap(c)),
                 EnlargeWithAncilla(),
                 ApplyLayout(),

--- a/tests/ml/test_helper_ml.py
+++ b/tests/ml/test_helper_ml.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
-from mqt.bench import benchmark_generator
-from mqt.bench.utils import qiskit_helper
+from mqt.bench import benchmark_generator, qiskit_helper
 from mqt.predictor import ml, reward
 
 


### PR DESCRIPTION
This PR introduces a workaround for the changes in `SabreLayout` introduced with Qiskit `v0.40.0`. 
Now, the called method does both apply a `layout` and a `routing` pass such that the returned circuit is completely mapped. Before, it only determine the `layout`. With the now used parameter which was added by Qiskit in the same version, only the `layout` is returned while in the background still the `routing` pass is done - the result ist just not returned.

Therefore, #77 would improve the overall integration of this particular action but also for all kind of similar actions. 